### PR TITLE
fix: add .org cors domains to allowed origins

### DIFF
--- a/freeCodeCamp/fcctesting.js
+++ b/freeCodeCamp/fcctesting.js
@@ -38,15 +38,15 @@
 const fs = require('fs');
 const cors = require('cors');
 
+const allowedOriginsMatcher = /^https?:\/\/([\w-]+\.)*freecodecamp.org/;
+
 module.exports = function (app) {
   
   app.use(function (req, res, next) {
-      var allowedOrigins = ['https://pricey-hugger.gomix.me', 'http://pricey-hugger.gomix.me', 'https://freecodecamp.com', 'https://beta.freecodecamp.com', 'http://freecodecamp.com', 'http://beta.freecodecamp.com','http://localhost:3000', 'https://localhost:3000', 'https://freecodecamp.org', 'https://beta.freecodecamp.org']
-       var origin = req.headers.origin;
-        if(allowedOrigins.indexOf(origin) > -1){
-             res.setHeader('Access-Control-Allow-Origin', origin);
-        }
-      //res.setHeader('Access-Control-Allow-Origin', 'https://pricey-hugger.gomix.me');
+      const origin = req.get('origin');
+      if(allowedOriginsMatcher.test(origin)) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+      }
       res.setHeader('Access-Control-Allow-Credentials', true);
       next();
   });

--- a/freeCodeCamp/fcctesting.js
+++ b/freeCodeCamp/fcctesting.js
@@ -41,7 +41,7 @@ const cors = require('cors');
 module.exports = function (app) {
   
   app.use(function (req, res, next) {
-      var allowedOrigins = ['https://pricey-hugger.gomix.me', 'http://pricey-hugger.gomix.me', 'https://freecodecamp.com', 'https://beta.freecodecamp.com', 'http://freecodecamp.com', 'http://beta.freecodecamp.com','http://localhost:3000', 'https://localhost:3000']
+      var allowedOrigins = ['https://pricey-hugger.gomix.me', 'http://pricey-hugger.gomix.me', 'https://freecodecamp.com', 'https://beta.freecodecamp.com', 'http://freecodecamp.com', 'http://beta.freecodecamp.com','http://localhost:3000', 'https://localhost:3000', 'https://freecodecamp.org', 'https://beta.freecodecamp.org']
        var origin = req.headers.origin;
         if(allowedOrigins.indexOf(origin) > -1){
              res.setHeader('Access-Control-Allow-Origin', origin);

--- a/freeCodeCamp/fcctesting.js
+++ b/freeCodeCamp/fcctesting.js
@@ -38,7 +38,7 @@
 const fs = require('fs');
 const cors = require('cors');
 
-const allowedOriginsMatcher = /^https?:\/\/([\w-]+\.)*freecodecamp.org/;
+const allowedOriginsMatcher = /^https?:\/\/([\w-]+\.)*freecodecamp\.org/;
 
 module.exports = function (app) {
   


### PR DESCRIPTION
Fixes issue #1 by adding https://beta.freecodecamp.org and https://www.freecodecamp.org as allowed origins in freeCodeCamp/fcctesting.js.  This makes testing work for the beta BCrypt hashing challenges, starting with this challenge: https://beta.freecodecamp.org/en/challenges/information-security-with-helmetjs/understand-bcrypt-hashes. 