### PR TITLE
fix: remove instruction hints and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# [bcrypt Challenges](https://www.freecodecamp.org/learn/information-security/information-security-with-helmetjs/understand-bcrypt-hashes)
+# [Information Security with HelmetJS - BCrypt](https://www.freecodecamp.org/learn/information-security/information-security-with-helmetjs/understand-bcrypt-hashes)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-**FreeCodeCamp** - bcrypt
-----
+# **freeCodeCamp**
 
-[![Run on Repl.it](https://repl.it/badge/github/freeCodeCamp/boilerplate-bcrypt)](https://repl.it/github/freeCodeCamp/boilerplate-bcrypt)
+## [bcrypt Challenges](https://www.freecodecamp.org/learn/information-security/information-security-with-helmetjs/understand-bcrypt-hashes)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
-# **freeCodeCamp**
-
-## [bcrypt Challenges](https://www.freecodecamp.org/learn/information-security/information-security-with-helmetjs/understand-bcrypt-hashes)
+# [bcrypt Challenges](https://www.freecodecamp.org/learn/information-security/information-security-with-helmetjs/understand-bcrypt-hashes)

--- a/server.js
+++ b/server.js
@@ -3,25 +3,41 @@ const express     = require('express');
 const bodyParser  = require('body-parser');
 const fccTesting  = require('./freeCodeCamp/fcctesting.js');
 const app         = express();
-
-fccTesting(app); //For FCC testing purposes
-
+fccTesting(app);
 const saltRounds = 12;
 const myPlaintextPassword = 'sUperpassw0rd!';
 const someOtherPlaintextPassword = 'pass123';
 
 
-//START_ASYNC -do not remove notes, place code between correct pair of notes.
 
 
 
-//END_ASYNC
-
-//START_SYNC
 
 
 
-//END_SYNC
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 app.listen(process.env.PORT || 3000, () => {});


### PR DESCRIPTION
Remove instruction hints and update readme.

Related to: https://github.com/freeCodeCamp/freeCodeCamp/issues/39720

Edit: We should probably wait on merging this until [the associated PR](https://github.com/freeCodeCamp/freeCodeCamp/pull/39954) hits production